### PR TITLE
LibraryManagerTest

### DIFF
--- a/src/test/java/ru/hh/school/unittesting/homework/LibraryManagerTest.java
+++ b/src/test/java/ru/hh/school/unittesting/homework/LibraryManagerTest.java
@@ -1,0 +1,116 @@
+package ru.hh.school.unittesting.homework;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import static org.mockito.Mockito.when;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+
+@ExtendWith(MockitoExtension.class)
+class LibraryManagerTest{
+
+  @Mock
+  private NotificationService notificationService;
+  @Mock
+  private UserService userService;
+
+  @InjectMocks
+  private LibraryManager libraryManager;
+
+  private static final double BASE_LATE_FEE_PER_DAY = 0.5;
+  private static final double BESTSELLER_MULTIPLIER = 1.5;
+  private static final double PREMIUM_MEMBER_DISCOUNT = 0.8;
+
+  @BeforeEach
+  void beforeEach(){
+    libraryManager = new LibraryManager(notificationService, userService);
+  }
+
+  @Test
+  public void borrowBook_NotActiveAccount_Test(){
+    when(userService.isUserActive(anyString())).thenReturn(false);
+    assertFalse(libraryManager.borrowBook("Book", "UserNotActive"));
+  }
+
+  @Test
+  public void borrowBook_NotAvailableCopies_Test(){
+    when(userService.isUserActive(anyString())).thenReturn(true);
+    assertFalse(libraryManager.borrowBook("BookNotFound", "User"));
+  }
+
+  @Test
+  public void borrowBook_Success_Test(){
+    libraryManager.addBook("Book", 1);
+    when(userService.isUserActive(anyString())).thenReturn(true);
+    assertEquals(1, libraryManager.getAvailableCopies("Book"));
+    assertTrue(libraryManager.borrowBook("Book", "User"));
+    assertEquals(0, libraryManager.getAvailableCopies("Book"));
+  }
+
+  @Test
+  public void returnBook_BookWasNotBorrowed_Test(){
+    assertFalse(libraryManager.returnBook("BookIsNotBorrowed", "User"));
+  }
+
+  @Test
+  public void returnBook_BookIsNotUsers_Test(){
+    libraryManager.addBook("BookIsBorrowed", 1);
+    when(userService.isUserActive(anyString())).thenReturn(true);
+    libraryManager.borrowBook("BookIsBorrowed", "User");
+    assertFalse(libraryManager.returnBook("BookIsBorrowed", "UserAnother"));
+  }
+
+  @Test
+  public void returnBook_Success_Test(){
+    libraryManager.addBook("Book", 1);
+    when(userService.isUserActive(anyString())).thenReturn(true);
+    libraryManager.borrowBook("Book", "User");
+    assertEquals(0, libraryManager.getAvailableCopies("Book"));
+    assertTrue(libraryManager.returnBook("Book", "User"));
+    assertEquals(1, libraryManager.getAvailableCopies("Book"));
+  }
+
+
+  @Test
+  public void getAvailableCopies_NotFound_Test(){
+    libraryManager.addBook("Book1", 4);
+    assertEquals(4, libraryManager.getAvailableCopies("Book1"));
+    assertEquals(0, libraryManager.getAvailableCopies("Book2"));
+  }
+
+
+  @Test
+  public void calculateDynamicLateFee_OverdueDaysNegative_Test(){
+    var exception = assertThrows(
+        IllegalArgumentException.class,
+        () -> libraryManager.calculateDynamicLateFee(-1, true, true)
+    );
+    assertEquals("Overdue days cannot be negative.", exception.getMessage());
+  }
+
+  @Test
+  public void calculateDynamicLateFee_ZeroDays_Test(){
+    assertEquals(0, libraryManager.calculateDynamicLateFee(0, true, true));
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+      "500, 1000, False, False",
+      "750, 1000, True, False",
+      "400, 1000, False, True",
+      "600, 1000, True, True",
+      "1.2, 2, True, True", // rounding test
+      "3.6, 6, True, True"  // rounding test
+  })
+  public void calculateDynamicLateFee_Calculation_Test(double feeValue, int daysCount, boolean isBestseller, boolean isPremiumMember){
+    assertEquals(feeValue, libraryManager.calculateDynamicLateFee(daysCount, isBestseller, isPremiumMember));
+  }
+}

--- a/src/test/java/ru/hh/school/unittesting/homework/LibraryManagerTest.java
+++ b/src/test/java/ru/hh/school/unittesting/homework/LibraryManagerTest.java
@@ -13,7 +13,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static org.mockito.Mockito.when;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.*;
 
 @ExtendWith(MockitoExtension.class)
 class LibraryManagerTest{
@@ -38,6 +38,8 @@ class LibraryManagerTest{
   public void borrowBook_NotAvailableCopies_Test(){
     when(userService.isUserActive(anyString())).thenReturn(true);
     assertFalse(libraryManager.borrowBook("BookNotFound", "User"));
+
+    Mockito.verify(notificationService, Mockito.never()).notifyUser(any(), any());
   }
 
   @Test
@@ -54,6 +56,8 @@ class LibraryManagerTest{
   @Test
   public void returnBook_BookWasNotBorrowed_Test(){
     assertFalse(libraryManager.returnBook("BookIsNotBorrowed", "User"));
+
+    Mockito.verify(notificationService, Mockito.never()).notifyUser(any(), any());
   }
 
   @Test
@@ -61,7 +65,10 @@ class LibraryManagerTest{
     libraryManager.addBook("BookIsBorrowed", 1);
     when(userService.isUserActive(anyString())).thenReturn(true);
     libraryManager.borrowBook("BookIsBorrowed", "User");
+    Mockito.verify(notificationService, Mockito.times(1)).notifyUser(any(), any());
+
     assertFalse(libraryManager.returnBook("BookIsBorrowed", "UserAnother"));
+    Mockito.verify(notificationService, Mockito.times(1)).notifyUser(any(), any());
   }
 
   @Test
@@ -82,6 +89,8 @@ class LibraryManagerTest{
     libraryManager.addBook("Book1", 4);
     assertEquals(4, libraryManager.getAvailableCopies("Book1"));
     assertEquals(0, libraryManager.getAvailableCopies("Book2"));
+
+    Mockito.verify(notificationService, Mockito.never()).notifyUser(any(), any());
   }
 
 
@@ -92,11 +101,15 @@ class LibraryManagerTest{
         () -> libraryManager.calculateDynamicLateFee(-1, true, true)
     );
     assertEquals("Overdue days cannot be negative.", exception.getMessage());
+
+    Mockito.verify(notificationService, Mockito.never()).notifyUser(any(), any());
   }
 
   @Test
   public void calculateDynamicLateFee_ZeroDays_Test(){
     assertEquals(0, libraryManager.calculateDynamicLateFee(0, true, true));
+
+    Mockito.verify(notificationService, Mockito.never()).notifyUser(any(), any());
   }
 
   @ParameterizedTest
@@ -110,5 +123,7 @@ class LibraryManagerTest{
   })
   public void calculateDynamicLateFee_Calculation_Test(double feeValue, int daysCount, boolean isBestseller, boolean isPremiumMember){
     assertEquals(feeValue, libraryManager.calculateDynamicLateFee(daysCount, isBestseller, isPremiumMember));
+
+    Mockito.verify(notificationService, Mockito.never()).notifyUser(any(), any());
   }
 }

--- a/src/test/java/ru/hh/school/unittesting/homework/LibraryManagerTest.java
+++ b/src/test/java/ru/hh/school/unittesting/homework/LibraryManagerTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import static org.mockito.Mockito.when;
 
@@ -25,19 +26,12 @@ class LibraryManagerTest{
   @InjectMocks
   private LibraryManager libraryManager;
 
-  private static final double BASE_LATE_FEE_PER_DAY = 0.5;
-  private static final double BESTSELLER_MULTIPLIER = 1.5;
-  private static final double PREMIUM_MEMBER_DISCOUNT = 0.8;
-
-  @BeforeEach
-  void beforeEach(){
-    libraryManager = new LibraryManager(notificationService, userService);
-  }
-
   @Test
   public void borrowBook_NotActiveAccount_Test(){
     when(userService.isUserActive(anyString())).thenReturn(false);
     assertFalse(libraryManager.borrowBook("Book", "UserNotActive"));
+
+    Mockito.verify(notificationService).notifyUser("UserNotActive", "Your account is not active.");
   }
 
   @Test
@@ -53,6 +47,8 @@ class LibraryManagerTest{
     assertEquals(1, libraryManager.getAvailableCopies("Book"));
     assertTrue(libraryManager.borrowBook("Book", "User"));
     assertEquals(0, libraryManager.getAvailableCopies("Book"));
+
+    Mockito.verify(notificationService).notifyUser("User", "You have borrowed the book: Book");
   }
 
   @Test
@@ -76,6 +72,8 @@ class LibraryManagerTest{
     assertEquals(0, libraryManager.getAvailableCopies("Book"));
     assertTrue(libraryManager.returnBook("Book", "User"));
     assertEquals(1, libraryManager.getAvailableCopies("Book"));
+
+    Mockito.verify(notificationService).notifyUser("User", "You have returned the book: Book");
   }
 
 


### PR DESCRIPTION
### Задача
[Ссылка на текст задачи.](https://github.com/ab-mathematician/hh-school-2024-unit-testing/blob/main/README.md)
* Покрыть юнит-тестами класс [LibraryManager](https://github.com/ab-mathematician/hh-school-2024-unit-testing/blob/main/src/main/java/ru/hh/school/unittesting/homework/LibraryManager.java).
* Постараться покрыть на 100%.
* Желательно написать хотя бы один параметризованный тест.
### Описание PR
Созданы тесты для LibraryManager для методов.
* borrowBook()
* returnBook()
* getAvailableCopies()
* calculateDynamicLateFee() - параметризованный

Не покрыты остались *addBook()*. Так как метод ничего не возвращает.
Тесты покрывают 100% строк, 100% веток.
### Вопросы
 * Как проверять значения _private_ полей?
 * Как тестировать математику? Хочется взять поля **BASE_LATE_FEE_PER_DAY** прямо из **LibraryManager**, но наверное это не очень правильно. Но с другой стороны завязываться на то, что значения этих полей не поменяются, тоже странно.
 * Норм ли называть тестовые методы так: **testedMethodName_whatTestDoes_Test** ?
 * Перед каждым полем тестового класса, который хочу обернуть в _mock_ нужно писать **@_Mock_**? Или другими словами, аннотация действует только на следующую за ней строку?
 * Можно ли в команде:  `Mockito.verify(notificationService, Mockito.times(1)).notifyUser(any(), any());` использовать не дважды `any()`, а посчитать вызовы метода с любым числом аргументов? Что-то типа `anyNumberOfArgs()` ?
* Как проверять, сколько раз запускался метод `notificationService.notifyUser()` в рамках выполнения `libraryManager.returnBook()`, а не в рамках выполнения одного целого тестового метода `returnBook_BookIsNotUsers_Test()` ?